### PR TITLE
Updated task 3 based on feedback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ In order to connect to the databases, 2 files must be created in the root direct
 - `.env.test`
 - `.env.development`
 
-Then add the single line to each file:  
+Then add this single line to each file:  
 `PGDATABASE=<database_name>`
 
 Replace `<database_name>` with the appropriate name (these can be found in the `setup.sql` file).

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -3,6 +3,7 @@ const app = require('../app.js');
 const db = require('../db/connection.js');
 const seed = require('../db/seeds/seed.js');
 const data = require('../db/data/test-data');
+const endpointsData = require('../endpoints.json');
 
 beforeEach(() => seed(data));
 afterAll(() => db.end());
@@ -18,20 +19,8 @@ describe('/api', () =>
                 .expect(200)
                 .then(({ body: { endpoints } }) =>
                 {
-                    parsedEndpoints = JSON.parse(endpoints);
-
-                    // 'GET /api' only has the 'description' property.
-                    expect(parsedEndpoints['GET /api'].description).toBe('Serves up a JSON representation of all the available endpoints of the API.');
-
-                    // Otherwise, rest should have all 4 properties: 'description', 'queries', 'requestFormat', and 'exampleResponse'.
-                    const remainingEndpoints = Object.values(parsedEndpoints).slice(1, Object.values(parsedEndpoints).length);
-                    remainingEndpoints.forEach(({ description, queries, requestFormat, exampleResponse }) =>
-                    {
-                        expect(typeof description).toBe('string');
-                        expect(Array.isArray(queries)).toBe(true);
-                        expect(typeof requestFormat).toBe('object');
-                        expect(typeof exampleResponse).toBe('object');
-                    });
+                    const parsedEndpointsResponse = JSON.parse(endpoints);
+                    expect(parsedEndpointsResponse).toEqual(endpointsData);
                 });
         });
     });

--- a/models/api.model.js
+++ b/models/api.model.js
@@ -1,6 +1,6 @@
-const fs = require('fs/promises');
+const endpointsData = require('../endpoints.json');
 
 exports.selectAPIEndpoints = () =>
 {
-    return fs.readFile(`${__dirname}/../endpoints.json`, 'utf8');
+    return Promise.resolve(JSON.stringify(endpointsData));
 };


### PR DESCRIPTION
- Refactored `api.model.js` to directly require instead of using `fs`
- Updated test to just simply check response is the same as the `endpoints.json` contents
- Slight correction on the `README.md`